### PR TITLE
add quickws

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ const (
 	NbioStd            = "nbio_std"
 	GoNettyWs          = "nettyws"
 	Nhooyr             = "nhooyr"
+	Quickws            = "quickws"
 )
 
 var Ports = map[string]string{
@@ -38,6 +39,7 @@ var Ports = map[string]string{
 	NbioStd:            "20001:20050",
 	GoNettyWs:          "21001:21050",
 	Nhooyr:             "22001:22050",
+	Quickws:            "23001:23050",
 }
 
 var FrameworkList = []string{
@@ -54,6 +56,7 @@ var FrameworkList = []string{
 	NbioStd,
 	GoNettyWs,
 	Nhooyr,
+	Quickws,
 }
 
 func GetFrameworkBenchmarkPorts(framework string) ([]int, error) {

--- a/frameworks/quickws/quickws.go
+++ b/frameworks/quickws/quickws.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
+	"go-websocket-benchmark/config"
+	"go-websocket-benchmark/frameworks"
+	"go-websocket-benchmark/logging"
+
+	"github.com/antlabs/quickws"
+)
+
+var (
+	_ = flag.Int("b", 1024, `read buffer size`)
+	_ = flag.Int("mrb", 4096, `max read buffer size`)
+	_ = flag.Int64("m", 1024*1024*1024*2, `memory limit`)
+	_ = flag.Int("mb", 10000, `max blocking online num, e.g. 10000`)
+)
+
+func main() {
+	flag.Parse()
+
+	addrs, err := config.GetFrameworkServerAddrs(config.Quickws)
+	if err != nil {
+		logging.Fatalf("GetFrameworkBenchmarkAddrs(%v) failed: %v", config.Quickws, err)
+	}
+	lns := startServers(addrs)
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	<-interrupt
+	for _, ln := range lns {
+		ln.Close()
+	}
+}
+
+func startServers(addrs []string) []net.Listener {
+	lns := make([]net.Listener, 0, len(addrs))
+	for _, addr := range addrs {
+		mux := &http.ServeMux{}
+		mux.HandleFunc("/ws", onWebsocket)
+		mux.HandleFunc("/pid", onServerPid)
+		server := http.Server{
+			// Addr:    addr,
+			Handler: mux,
+		}
+		ln, err := frameworks.Listen("tcp", addr)
+		if err != nil {
+			logging.Fatalf("Listen failed: %v", err)
+		}
+		lns = append(lns, ln)
+		go func() {
+			logging.Printf("server exit: %v", server.Serve(ln))
+		}()
+	}
+	return lns
+}
+
+func onServerPid(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "%d", os.Getpid())
+}
+
+func onWebsocket(w http.ResponseWriter, r *http.Request) {
+	c, err := quickws.Upgrade(w, r,
+		// quickws.WithServerDecompression(),
+		// quickws.WithServerIgnorePong(),
+		quickws.WithServerCallback(&Handler{}),
+		quickws.WithServerReadTimeout(5*time.Second),
+	)
+	if err != nil {
+		log.Printf("upgrade failed: %v", err)
+		return
+	}
+	//c.SetReadDeadline(time.Time{})
+	c.ReadLoop()
+}
+
+type Handler struct {
+	quickws.DefCallback
+}
+
+func (h *Handler) OnMessage(c *quickws.Conn, op quickws.Opcode, msg []byte) {
+	_ = c.WriteMessage(op, msg)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go-websocket-benchmark
 go 1.19
 
 require (
+	github.com/antlabs/quickws v0.0.8-0.20230611095020-7196d73ff055
 	github.com/bytedance/gopkg v0.0.0-20230531144706-a12972768317
 	github.com/cloudwego/hertz v0.6.4
 	github.com/fasthttp/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/antlabs/quickws v0.0.8-0.20230611095020-7196d73ff055 h1:0v2oJO9/dyYmbawOCxkfhAbiI+U7OaZgEFl3rbyUEgo=
+github.com/antlabs/quickws v0.0.8-0.20230611095020-7196d73ff055/go.mod h1:x835Q2QyOUPcqpvZ1SkdHZikCvXqb/oEbrfCslYs9O4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=

--- a/script/config.sh
+++ b/script/config.sh
@@ -8,6 +8,7 @@ SleepTime=5
 frameworks=(
     "fasthttp"
     "gobwas"
+    "quickws"
     "gorilla"
     "gws"
     "gws_std"


### PR DESCRIPTION
先上传个初始版本，后面跑下profile再优化下。
----------------------------------------------------------------------------------------------------
20230611 19:10.14.351 [Connections] Report

|    Framework     |  TPS  | Min  |   Avg   |   Max    | TP50 | TP75 |   TP90   |   TP95   |   TP99   |   Used   | Total | Success | Failed | Concurrency |
|     ---          |  ---  | ---  |   ---   |   ---    | ---  | ---  |   ---    |   ---    |   ---    |   ---    |  ---  |   ---   |  ---   |     ---     |
|   fasthttp       | 26386 | 30ns | 59.93ms | 377.50ms | 50ns | 50ns | 298.32ms | 314.01ms | 373.64ms | 378.99ms | 10000 |  10000  |   0    |    2000     |
|    gobwas        | 28969 | 30ns | 52.39ms | 344.61ms | 40ns | 50ns | 259.65ms | 269.53ms | 340.09ms | 345.19ms | 10000 |  10000  |   0    |    2000     |
|    gorilla       | 27951 | 30ns | 54.21ms | 355.65ms | 40ns | 50ns | 264.35ms | 292.61ms | 343.92ms | 357.76ms | 10000 |  10000  |   0    |    2000     |
|     gws          | 25398 | 20ns | 59.55ms | 393.12ms | 40ns | 50ns | 290.86ms | 305.89ms | 383.95ms | 393.73ms | 10000 |  10000  |   0    |    2000     |
|    gws_std       | 24328 | 30ns | 62.34ms | 409.95ms | 40ns | 50ns | 321.40ms | 332.91ms | 407.42ms | 411.04ms | 10000 |  10000  |   0    |    2000     |
|    hertz         | 23561 | 20ns | 70.60ms | 423.32ms | 40ns | 40ns | 346.88ms | 372.37ms | 409.15ms | 424.42ms | 10000 |  10000  |   0    |    2000     |
|   hertz_std      | 28251 | 30ns | 55.28ms | 353.04ms | 40ns | 50ns | 256.95ms | 298.45ms | 349.34ms | 353.96ms | 10000 |  10000  |   0    |    2000     |
|  nbio_blocking   | 30060 | 30ns | 52.95ms | 332.05ms | 41ns | 50ns | 259.00ms | 269.09ms | 329.40ms | 332.66ms | 10000 |  10000  |   0    |    2000     |
|   nbio_mixed     | 27000 | 30ns | 60.63ms | 370.16ms | 40ns | 50ns | 317.22ms | 329.92ms | 365.85ms | 370.37ms | 10000 |  10000  |   0    |    2000     |
| nbio_nonblocking | 30298 | 30ns | 52.07ms | 328.76ms | 40ns | 50ns | 257.87ms | 268.46ms | 325.92ms | 330.05ms | 10000 |  10000  |   0    |    2000     |
|   nbio_std       | 26140 | 30ns | 59.38ms | 380.75ms | 40ns | 50ns | 298.43ms | 335.61ms | 376.41ms | 382.55ms | 10000 |  10000  |   0    |    2000     |
|    nettyws       | 27237 | 30ns | 55.64ms | 365.21ms | 40ns | 50ns | 264.20ms | 290.58ms | 354.38ms | 367.14ms | 10000 |  10000  |   0    |    2000     |
|    nhooyr        | 28575 | 30ns | 55.55ms | 348.91ms | 40ns | 50ns | 261.28ms | 288.52ms | 344.63ms | 349.95ms | 10000 |  10000  |   0    |    2000     |
|    quickws       | 25411 | 30ns | 61.33ms | 391.93ms | 40ns | 50ns | 305.22ms | 317.18ms | 387.20ms | 393.53ms | 10000 |  10000  |   0    |    2000     |
----------------------------------------------------------------------------------------------------
20230611 19:10.14.352 [BenchEcho] Report

|    Framework     |  TPS   |   Min   |   Avg   |   Max    |  TP50   |  TP75   |  TP90   |  TP95   |   TP99   |  Used  |  Total  | Success | Failed | Conns | Concurrency | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |  ---   |   ---   |   ---   |   ---    |   ---   |   ---   |   ---   |   ---   |   ---    |  ---   |   ---   |   ---   |  ---   |  ---  |     ---     |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
|   fasthttp       | 265778 | 16.93us | 37.51ms | 224.10ms | 35.53ms | 40.19ms | 45.64ms | 47.09ms | 50.27ms  | 7.53s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 581.74  | 591.08  | 621.76  | 243.59M | 249.26M | 254.79M |
|    gobwas        | 217435 | 20.75us | 45.86ms | 306.15ms | 43.04ms | 47.81ms | 60.82ms | 65.84ms | 126.23ms | 9.20s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 763.09  | 782.41  | 790.70  | 347.88M | 351.14M | 355.52M |
|    gorilla       | 268370 | 15.10us | 37.14ms | 207.71ms | 35.07ms | 38.96ms | 45.60ms | 47.08ms | 52.79ms  | 7.45s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 563.52  | 574.66  | 582.89  | 243.34M | 248.40M | 253.51M |
|     gws          | 299656 | 15.78us | 33.27ms | 177.79ms | 31.28ms | 33.09ms | 41.30ms | 42.46ms | 52.99ms  | 6.67s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 531.89  | 540.72  | 547.88  | 142.23M | 151.32M | 158.64M |
|    gws_std       | 292594 | 14.12us | 34.05ms | 201.26ms | 32.05ms | 33.95ms | 42.13ms | 43.47ms | 55.77ms  | 6.84s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 443.63  | 536.95  | 566.65  | 255.40M | 272.01M | 306.10M |
|    hertz         | 172567 | 4.93ms  | 57.74ms | 175.41ms | 52.55ms | 58.35ms | 89.21ms | 94.20ms | 107.21ms | 11.59s | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 399.92  | 403.15  | 415.93  | 493.89M | 510.82M | 529.54M |
|   hertz_std      | 240143 | 20.70us | 41.51ms | 233.20ms | 41.03ms | 44.26ms | 48.17ms | 50.43ms | 58.66ms  | 8.33s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 671.83  | 689.69  | 700.86  | 317.89M | 323.08M | 328.28M |
|  nbio_blocking   | 267894 | 21.66us | 37.21ms | 199.68ms | 35.24ms | 39.67ms | 45.11ms | 46.70ms | 55.21ms  | 7.47s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 595.87  | 612.84  | 635.84  | 134.43M | 167.85M | 194.99M |
|   nbio_mixed     | 269091 | 18.77us | 37.03ms | 232.74ms | 34.91ms | 39.29ms | 44.85ms | 46.51ms | 67.87ms  | 7.43s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 602.66  | 618.98  | 646.89  | 159.73M | 200.13M | 223.15M |
| nbio_nonblocking | 238657 | 28.41us | 41.75ms | 233.23ms | 38.55ms | 52.63ms | 67.62ms | 77.81ms | 107.65ms | 8.38s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 717.87  | 739.58  | 749.85  | 95.46M  | 112.03M | 118.45M |
|   nbio_std       | 286024 | 18.34us | 34.86ms | 210.08ms | 32.50ms | 35.77ms | 42.71ms | 44.44ms | 95.42ms  | 6.99s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 559.89  | 576.24  | 619.88  | 152.34M | 178.00M | 194.76M |
|    nettyws       | 246385 | 19.03us | 40.46ms | 250.54ms | 39.41ms | 42.77ms | 48.35ms | 51.60ms | 68.55ms  | 8.12s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 681.84  | 694.21  | 731.86  | 193.60M | 226.19M | 247.68M |
|    nhooyr        | 223066 | 22.05us | 44.66ms | 197.69ms | 41.20ms | 43.91ms | 60.60ms | 66.01ms | 104.99ms | 8.97s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 767.44  | 794.16  | 798.84  | 358.07M | 370.27M | 382.62M |
|    quickws       | 293740 | 16.99us | 33.94ms | 117.92ms | 32.03ms | 34.34ms | 42.19ms | 43.34ms | 47.44ms  | 6.81s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 447.88  | 560.95  | 619.55  | 259.78M | 279.07M | 284.48M |
----------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------
20230611 19:10.14.353 [%!B(string=)enchRate] Report

|    Framework     | Duration | Packet Sent | Bytes Sent | Packet Recv | Bytes Recv | Conns | ConnRate | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |   ---    |     ---     |    ---     |     ---     |    ---     |  ---  |   ---    |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
|   fasthttp       |  10.00s  |   3154724   |   3.01G    |   3154724   |   3.01G    | 10000 |    5     |  1024   | 623.03  | 631.60  | 644.40  | 260.95M | 270.58M | 280.51M |
|    gobwas        |  10.00s  |   2585378   |   2.47G    |   2585378   |   2.47G    | 10000 |    5     |  1024   | 746.74  | 765.47  | 781.79  | 355.52M | 355.52M | 355.52M |
|    gorilla       |  10.00s  |   3238072   |   3.09G    |   3238072   |   3.09G    | 10000 |    5     |  1024   | 577.53  | 582.43  | 588.83  | 260.43M | 270.03M | 280.27M |
|     gws          |  10.00s  |   3367515   |   3.21G    |   3367515   |   3.21G    | 10000 |    5     |  1024   | 532.50  | 544.83  | 563.89  | 175.59M | 176.21M | 177.03M |
|    gws_std       |  10.00s  |   3253706   |   3.10G    |   3253706   |   3.10G    | 10000 |    5     |  1024   | 569.66  | 582.39  | 610.24  | 324.31M | 333.71M | 344.79M |
|    hertz         |  10.00s  |   3321224   |   3.17G    |   3315532   |   3.16G    | 10000 |    5     |  1024   | 419.36  | 422.54  | 425.51  | 566.46M | 631.28M | 695.39M |
|   hertz_std      |  10.00s  |   3129769   |   2.98G    |   3129769   |   2.98G    | 10000 |    5     |  1024   | 638.17  | 644.46  | 656.93  | 334.43M | 342.82M | 352.04M |
|  nbio_blocking   |  10.00s  |   3337065   |   3.18G    |   3337065   |   3.18G    | 10000 |    5     |  1024   | 609.90  | 615.57  | 624.50  | 195.99M | 200.61M | 202.54M |
|   nbio_mixed     |  10.00s  |   3164117   |   3.02G    |   3164117   |   3.02G    | 10000 |    5     |  1024   | 639.18  | 652.23  | 669.17  | 224.00M | 282.41M | 327.41M |
| nbio_nonblocking |  10.00s  |   3003107   |   2.86G    |   3003107   |   2.86G    | 10000 |    5     |  1024   | 734.44  | 742.06  | 751.15  | 120.89M | 124.54M | 127.18M |
|   nbio_std       |  10.00s  |   3270300   |   3.12G    |   3270300   |   3.12G    | 10000 |    5     |  1024   | 603.62  | 619.71  | 635.09  | 195.43M | 202.37M | 209.25M |
|    nettyws       |  10.00s  |   3059003   |   2.92G    |   3059003   |   2.92G    | 10000 |    5     |  1024   | 669.73  | 684.85  | 694.05  | 240.00M | 246.75M | 262.38M |
|    nhooyr        |  10.00s  |   2823954   |   2.69G    |   2823954   |   2.69G    | 10000 |    5     |  1024   | 794.98  | 797.09  | 800.38  | 391.16M | 409.40M | 427.45M |
|    quickws       |  10.00s  |   3362419   |   3.21G    |   3362419   |   3.21G    | 10000 |    5     |  1024   | 587.02  | 602.63  | 617.92  | 325.58M | 350.75M | 355.96M |
----------------------------------------------------------------------------------------------------

generate report done
--------------------------------------------------------------