### PR TITLE
更新quickws，性能相比上个commit略有提升

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go-websocket-benchmark
 go 1.19
 
 require (
-	github.com/antlabs/quickws v0.0.8-0.20230611095020-7196d73ff055
+	github.com/antlabs/quickws v0.0.8-0.20230613152255-f6c04eca7f9f
 	github.com/bytedance/gopkg v0.0.0-20230531144706-a12972768317
 	github.com/cloudwego/hertz v0.6.4
 	github.com/fasthttp/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/antlabs/quickws v0.0.8-0.20230611095020-7196d73ff055 h1:0v2oJO9/dyYmbawOCxkfhAbiI+U7OaZgEFl3rbyUEgo=
-github.com/antlabs/quickws v0.0.8-0.20230611095020-7196d73ff055/go.mod h1:x835Q2QyOUPcqpvZ1SkdHZikCvXqb/oEbrfCslYs9O4=
+github.com/antlabs/quickws v0.0.8-0.20230613152255-f6c04eca7f9f h1:ydFL+F7PN76bIfzz+P7eOm+0PGQ+5spAo4KwAnsh0KA=
+github.com/antlabs/quickws v0.0.8-0.20230613152255-f6c04eca7f9f/go.mod h1:x835Q2QyOUPcqpvZ1SkdHZikCvXqb/oEbrfCslYs9O4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=


### PR DESCRIPTION
----------------------------------------------------------------------------------------------------
20230613 23:34.08.472 [Connections] Report

|    Framework     |  TPS  | Min  |   Avg   |   Max    | TP50 | TP75 |   TP90   |   TP95   |   TP99   |   Used   | Total | Success | Failed | Concurrency |
|     ---          |  ---  | ---  |   ---   |   ---    | ---  | ---  |   ---    |   ---    |   ---    |   ---    |  ---  |   ---   |  ---   |     ---     |
|   fasthttp       | 26195 | 30ns | 56.95ms | 380.89ms | 40ns | 50ns | 269.94ms | 279.81ms | 377.65ms | 381.75ms | 10000 |  10000  |   0    |    2000     |
|    gobwas        | 25701 | 30ns | 57.51ms | 388.29ms | 40ns | 50ns | 284.10ms | 298.12ms | 380.46ms | 389.08ms | 10000 |  10000  |   0    |    2000     |
|    gorilla       | 25704 | 30ns | 63.18ms | 387.88ms | 40ns | 50ns | 291.70ms | 382.30ms | 384.56ms | 389.03ms | 10000 |  10000  |   0    |    2000     |
|     gws          | 25494 | 30ns | 53.65ms | 391.35ms | 41ns | 50ns | 246.76ms | 302.38ms | 385.92ms | 392.24ms | 10000 |  10000  |   0    |    2000     |
|    gws_std       | 30795 | 30ns | 50.88ms | 323.43ms | 40ns | 41ns | 247.85ms | 274.47ms | 316.32ms | 324.73ms | 10000 |  10000  |   0    |    2000     |
|    hertz         | 25312 | 30ns | 63.99ms | 393.59ms | 40ns | 50ns | 309.78ms | 339.71ms | 381.80ms | 395.06ms | 10000 |  10000  |   0    |    2000     |
|   hertz_std      | 27392 | 30ns | 57.07ms | 364.05ms | 40ns | 50ns | 281.09ms | 304.12ms | 358.95ms | 365.07ms | 10000 |  10000  |   0    |    2000     |
|  nbio_blocking   | 30265 | 30ns | 51.32ms | 329.34ms | 40ns | 50ns | 259.05ms | 274.26ms | 325.01ms | 330.41ms | 10000 |  10000  |   0    |    2000     |
|   nbio_mixed     | 24096 | 30ns | 59.06ms | 414.00ms | 40ns | 50ns | 301.31ms | 310.63ms | 411.40ms | 414.99ms | 10000 |  10000  |   0    |    2000     |
| nbio_nonblocking | 26024 | 30ns | 58.14ms | 383.25ms | 40ns | 50ns | 282.38ms | 299.83ms | 380.51ms | 384.25ms | 10000 |  10000  |   0    |    2000     |
|   nbio_std       | 26825 | 30ns | 57.73ms | 371.55ms | 41ns | 50ns | 288.56ms | 302.82ms | 364.42ms | 372.78ms | 10000 |  10000  |   0    |    2000     |
|    nettyws       | 28799 | 30ns | 55.85ms | 345.49ms | 40ns | 50ns | 272.03ms | 292.68ms | 334.05ms | 347.23ms | 10000 |  10000  |   0    |    2000     |
|    nhooyr        | 26779 | 30ns | 56.61ms | 372.16ms | 41ns | 50ns | 269.59ms | 298.47ms | 360.61ms | 373.42ms | 10000 |  10000  |   0    |    2000     |
|    quickws       | 29878 | 30ns | 54.96ms | 333.57ms | 40ns | 41ns | 266.47ms | 276.74ms | 328.86ms | 334.69ms | 10000 |  10000  |   0    |    2000     |
----------------------------------------------------------------------------------------------------
20230613 23:34.08.474 [BenchEcho] Report

|    Framework     |  TPS   |   Min   |   Avg   |   Max    |  TP50   |  TP75   |  TP90   |  TP95   |   TP99   |  Used  |  Total  | Success | Failed | Conns | Concurrency | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |  ---   |   ---   |   ---   |   ---    |   ---   |   ---   |   ---   |   ---   |   ---    |  ---   |   ---   |   ---   |  ---   |  ---  |     ---     |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
|   fasthttp       | 290749 | 16.47us | 34.30ms | 243.87ms | 31.85ms | 34.29ms | 41.74ms | 43.24ms | 90.94ms  | 6.88s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 510.91  | 582.29  | 643.84  | 245.53M | 251.12M | 256.41M |
|    gobwas        | 228590 | 17.46us | 43.59ms | 291.21ms | 39.35ms | 45.19ms | 59.30ms | 69.32ms | 126.99ms | 8.75s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 584.65  | 764.97  | 793.72  | 351.68M | 353.71M | 355.74M |
|    gorilla       | 291591 | 14.50us | 34.20ms | 259.40ms | 32.22ms | 34.47ms | 41.94ms | 43.18ms | 51.53ms  | 6.86s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 480.62  | 569.25  | 605.88  | 243.50M | 249.17M | 254.61M |
|     gws          | 312335 | 14.92us | 31.93ms | 170.51ms | 30.01ms | 31.50ms | 40.00ms | 41.08ms | 47.97ms  | 6.40s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 560.90  | 567.73  | 586.90  | 149.37M | 161.31M | 175.16M |
|    gws_std       | 315836 | 15.20us | 31.57ms | 209.35ms | 29.49ms | 31.26ms | 39.36ms | 40.55ms | 56.24ms  | 6.33s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 558.88  | 573.72  | 591.89  | 247.72M | 277.21M | 317.71M |
|    hertz         | 177194 | 8.63ms  | 56.23ms | 165.00ms | 51.41ms | 55.44ms | 85.90ms | 91.30ms | 105.50ms | 11.29s | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 417.95  | 422.05  | 431.93  | 493.34M | 523.19M | 532.32M |
|   hertz_std      | 258451 | 24.43us | 38.57ms | 248.80ms | 36.58ms | 40.49ms | 47.67ms | 51.89ms | 72.82ms  | 7.74s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 506.51  | 674.38  | 708.84  | 322.00M | 327.62M | 332.95M |
|  nbio_blocking   | 287885 | 16.82us | 34.64ms | 276.23ms | 32.19ms | 36.04ms | 42.46ms | 45.15ms | 84.56ms  | 6.95s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 594.22  | 640.77  | 674.85  | 150.61M | 183.19M | 195.65M |
|   nbio_mixed     | 290490 | 18.59us | 34.32ms | 314.88ms | 31.18ms | 35.60ms | 41.98ms | 47.48ms | 108.06ms | 6.88s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 557.79  | 640.23  | 683.72  | 163.96M | 205.39M | 227.45M |
| nbio_nonblocking | 250079 | 17.53us | 39.86ms | 188.80ms | 36.56ms | 50.08ms | 64.97ms | 77.07ms | 105.64ms | 8.00s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 734.78  | 744.23  | 753.83  | 103.48M | 116.00M | 120.32M |
|   nbio_std       | 304832 | 16.73us | 32.71ms | 193.19ms | 30.52ms | 32.54ms | 40.56ms | 41.79ms | 63.10ms  | 6.56s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 587.88  | 606.01  | 633.79  | 171.86M | 175.70M | 180.53M |
|    nettyws       | 254960 | 17.38us | 39.11ms | 261.53ms | 36.77ms | 39.71ms | 51.54ms | 54.16ms | 93.05ms  | 7.84s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 597.82  | 741.66  | 798.76  | 192.39M | 222.02M | 234.08M |
|    nhooyr        | 240312 | 16.78us | 41.46ms | 173.00ms | 38.98ms | 41.26ms | 54.11ms | 56.68ms | 70.86ms  | 8.32s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 794.84  | 798.34  | 801.88  | 358.99M | 370.33M | 381.53M |
|    quickws       | 314238 | 15.27us | 31.73ms | 206.61ms | 29.68ms | 31.18ms | 39.59ms | 40.75ms | 56.40ms  | 6.36s  | 2000000 | 2000000 |   0    | 10000 |    10000    |  1024   | 553.26  | 573.58  | 597.88  | 263.55M | 290.29M | 301.66M |
----------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------
20230613 23:34.08.474 [BenchRate] Report

|    Framework     | Duration | Packet Sent | Bytes Sent | Packet Recv | Bytes Recv | Conns | SendRate | Payload | CPU Min | CPU Avg | CPU Max | MEM Min | MEM Avg | MEM Max |
|     ---          |   ---    |     ---     |    ---     |     ---     |    ---     |  ---  |   ---    |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |   ---   |
|   fasthttp       |  10.00s  |   8019190   |   7.65G    |   8019190   |   7.65G    | 10000 |   100    |  1024   | 749.22  | 780.00  | 787.67  | 268.99M | 285.08M | 290.98M |
|    gobwas        |  10.00s  |   5010150   |   4.78G    |   4894041   |   4.67G    | 10000 |   100    |  1024   | 771.61  | 777.98  | 784.73  | 429.57M | 440.11M | 457.77M |
|    gorilla       |  10.00s  |   8013400   |   7.64G    |   7988780   |   7.62G    | 10000 |   100    |  1024   | 784.79  | 786.49  | 787.86  | 266.22M | 292.30M | 317.75M |
|     gws          |  10.00s  |   7674120   |   7.32G    |   7673564   |   7.32G    | 10000 |   100    |  1024   | 574.18  | 604.84  | 656.76  | 176.57M | 176.94M | 178.05M |
|    gws_std       |  10.00s  |   7692040   |   7.34G    |   7692040   |   7.34G    | 10000 |   100    |  1024   | 587.65  | 607.62  | 634.45  | 330.20M | 352.16M | 357.23M |
|    hertz         |  10.00s  |   5703715   |   5.44G    |   5539173   |   5.28G    | 10000 |   100    |  1024   | 626.94  | 638.67  | 651.90  | 562.11M | 663.93M | 765.04M |
|   hertz_std      |  10.00s  |   7711510   |   7.35G    |   7711510   |   7.35G    | 10000 |   100    |  1024   | 744.69  | 783.41  | 791.01  | 344.04M | 353.05M | 356.00M |
|  nbio_blocking   |  10.00s  |   7877860   |   7.51G    |   7849878   |   7.49G    | 10000 |   100    |  1024   | 782.75  | 794.61  | 820.66  | 201.41M | 222.68M | 244.49M |
|   nbio_mixed     |  10.00s  |   7830925   |   7.47G    |   7830925   |   7.47G    | 10000 |   100    |  1024   | 759.17  | 790.75  | 804.24  | 274.80M | 362.74M | 438.47M |
| nbio_nonblocking |  10.00s  |   6833275   |   6.52G    |   6794337   |   6.48G    | 10000 |   100    |  1024   | 777.74  | 785.65  | 791.78  | 177.49M | 194.87M | 214.38M |
|   nbio_std       |  10.00s  |   7766025   |   7.41G    |   7706185   |   7.35G    | 10000 |   100    |  1024   | 781.67  | 791.43  | 795.69  | 209.18M | 212.73M | 219.23M |
|    nettyws       |  10.00s  |   7703550   |   7.35G    |   7703550   |   7.35G    | 10000 |   100    |  1024   | 748.72  | 782.84  | 795.24  | 235.78M | 273.02M | 280.60M |
|    nhooyr        |  10.00s  |   6282410   |   5.99G    |   6184478   |   5.90G    | 10000 |   100    |  1024   | 797.48  | 798.59  | 798.90  | 401.56M | 440.80M | 476.96M |
|    quickws       |  10.00s  |   8036065   |   7.66G    |   7986889   |   7.62G    | 10000 |   100    |  1024   | 789.06  | 792.04  | 794.72  | 342.36M | 372.51M | 386.72M |
----------------------------------------------------------------------------------------------------

generate report done
--------------------------------------------------------------